### PR TITLE
Update copyright to CC0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Made and deployed with [logos site-builder](https://github.com/acid-info/logos-s
 2. Proceed with changes, push to `origin` and open a Pull Request against `staging`;
 3. Once approved, merge pull request, check changes on [staging.vac.dev](https://staging.vac.dev);
 4. Once ready to promote to live website, rebase master on staging: `git checkout master; git pull master; git rebase origin/staging; git push`.
+
+# Copyright
+
+For all research posts under https://vac.dev/research, copyright and related rights are waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Addresses https://github.com/vacp2p/vac.dev/issues/73 by ensuring write-ups are CC0.

This is already basically the case but this just makes it explicit, similar to what we've done for RFC specs.

Checkbox for authors to fill in:

- [x] @oskarth 
- [x] @decanus 
- [x] @jm-clius 
- [x] @staheri14
- [x] @kaiserd 
- [x] @s1fr0 
- [x] @rymnc 
- [x] @thecirce 

https://github.com/vacp2p/vac.dev/tree/staging/_data/authors

https://creativecommons.org/share-your-work/public-domain/cc0/

---

Please confirm by writing a comment/reviewing this PR with:

"I acknowledge that research posts are placed under CC0."